### PR TITLE
Fix get-task-allow warning was always shown.

### DIFF
--- a/checkipa
+++ b/checkipa
@@ -199,7 +199,7 @@ class IntegrityCheck(object):
             results.append({'label': 'Push Notification',
                             'description': 'aps-environment key is not set'})
 
-        if True or self.warnings['dist_dev']:
+        if self.warnings['dist_dev']:
             dist_warn_desc = "code signing Entitlements 'get-task-allow' value is set to YES; should be NO"
             results.append({'label': 'Distribution',
                             'description': dist_warn_desc})


### PR DESCRIPTION
Thanks for this checker. I was wondering why all my ipas had get-task-allow set to true... Apparently it was introduced in 17aac58a4eac54eb0e0e344b71d905f82bf53c8c during refactoring.
